### PR TITLE
fix: add addTrailingSlash: false to Socket.IO server

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -13,6 +13,7 @@ var app = express()
 var server = http.createServer(app)
 var { Server } = require("socket.io")
 var io = new Server(server, {
+	addTrailingSlash: false,
 	cors: {
 		origin: ["https://admin.socket.io", process.env.SOCKET_ADMIN_ORIGIN].filter(Boolean),
 		credentials: true,


### PR DESCRIPTION
## Summary

- Adds `addTrailingSlash: false` to the Socket.IO `Server` constructor

## Problem

Some reverse proxies (e.g. Oathkeeper) normalize request paths and strip the trailing slash from `/socket.io/` before forwarding to the upstream. This causes Socket.IO's engine.io handler to return 404, because by default it only matches `/socket.io/` (with trailing slash).

**Reproduction:**
- `GET /socket.io/?EIO=4&transport=polling` → 200 ✅
- `GET /socket.io?EIO=4&transport=polling` → 404 ❌ (what the proxy sends)

## Fix

Setting `addTrailingSlash: false` (available since Socket.IO 4.6.1, currently on 4.8.1) makes Socket.IO also accept requests at `/socket.io` without the trailing slash.

**Validated** by running a standalone test server inside the pod:
```
No-slash status: 200 | Body: 0{"sid":"...","upgrades":["websocket"],...}
```

## Test plan

- [ ] Build and push new image
- [ ] Update image tag in skynetk8s values.yaml
- [ ] Verify servers appear in the UI at ipmi.p0i.re

🤖 Generated with [Claude Code](https://claude.ai/claude-code)